### PR TITLE
Add exportResults to tournament service

### DIFF
--- a/frontend/src/services/tournamentService.js
+++ b/frontend/src/services/tournamentService.js
@@ -136,17 +136,29 @@ const tournamentService = {
     }
   },
 
-  async eliminatePlayer(tournamentId, userId) {
-    try {
-      const response = await axios.post(`${API_URL}/tournaments/${tournamentId}/eliminate`, {
-        userId
-      });
-      return response.data;
-    } catch (error) {
-      console.error('Eliminate error:', error);
-      throw this._handleError(error);
-    }
-  },
+    async eliminatePlayer(tournamentId, userId) {
+      try {
+        const response = await axios.post(`${API_URL}/tournaments/${tournamentId}/eliminate`, {
+          userId
+        });
+        return response.data;
+      } catch (error) {
+        console.error('Eliminate error:', error);
+        throw this._handleError(error);
+      }
+    },
+
+    async exportResults(tournamentId) {
+      try {
+        const response = await axios.get(`${API_URL}/tournaments/${tournamentId}/export`, {
+          responseType: 'blob'
+        });
+        return response.data;
+      } catch (error) {
+        console.error('Export results error:', error);
+        throw this._handleError(error);
+      }
+    },
 
   async updateTournamentLevel(tournamentId, level, blindIndex, isBreak) {
     try {


### PR DESCRIPTION
## Summary
- support exporting tournament results as a blob

## Testing
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_683fa751a6f4832488e9bbc4658a2e5c