### PR TITLE
Fix Settle Up visibility

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
 import TournamentList from './components/tournaments/TournamentList';
 import CreateTournament from './components/tournaments/CreateTournament';
-import TournamentDetail from './components/tournaments/TournamentDetail';
+import TournamentDetails from './components/tournaments/TournamentDetails';
 import Login from './components/auth/Login';
 import Register from './components/auth/Register';
 import StaffRoute from './components/auth/StaffRoute';
@@ -105,7 +105,7 @@ function App() {
                 </StaffRoute>
               }
             />
-            <Route path="/tournaments/:id" element={<TournamentDetail />} />
+            <Route path="/tournaments/:id" element={<TournamentDetails />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/utils/blindStructures.js
+++ b/frontend/src/utils/blindStructures.js
@@ -3,66 +3,18 @@ const BLIND_STRUCTURES = {
   // Para stacks de 10,000 a 15,000
   small: {
     name: 'Turbo (15 min)',
-    levels: [
-      { level: 1, small_blind: 100, big_blind: 100, duration: 15 },
-      { level: 2, small_blind: 100, big_blind: 200, duration: 15 },
-      { level: 3, small_blind: 100, big_blind: 300, duration: 15 },
-      { level: 4, small_blind: 200, big_blind: 400, duration: 15 },
-      { level: 5, small_blind: 300, big_blind: 600, duration: 15 },
-      { level: 6, small_blind: 400, big_blind: 800, duration: 15 },
-      { level: 7, small_blind: 500, big_blind: 1000, duration: 15 },
-      { level: 8, small_blind: 600, big_blind: 1200, duration: 15 },
-      { level: 9, small_blind: 800, big_blind: 1600, duration: 15 },
-      { level: 10, small_blind: 1000, big_blind: 2000, duration: 15 },
-      { level: 11, small_blind: 1500, big_blind: 3000, duration: 15 },
-      { level: 12, small_blind: 2000, big_blind: 4000, duration: 15 },
-    ]
     levels: generateBlindLevels(15)
   },
   
   // Para stacks de 15,000 a 25,000
   medium: {
     name: 'Regular (20 min)',
-    levels: [
-      { level: 1, small_blind: 100, big_blind: 100, duration: 20 },
-      { level: 2, small_blind: 100, big_blind: 200, duration: 20 },
-      { level: 3, small_blind: 100, big_blind: 300, duration: 20 },
-      { level: 4, small_blind: 200, big_blind: 400, duration: 20 },
-      { level: 5, small_blind: 300, big_blind: 600, duration: 20 },
-      { level: 6, small_blind: 400, big_blind: 800, duration: 20 },
-      { level: 7, small_blind: 500, big_blind: 1000, duration: 20 },
-      { level: 8, small_blind: 600, big_blind: 1200, duration: 20 },
-      { level: 9, small_blind: 800, big_blind: 1600, duration: 20 },
-      { level: 10, small_blind: 1000, big_blind: 2000, duration: 20 },
-      { level: 11, small_blind: 1500, big_blind: 3000, duration: 20 },
-      { level: 12, small_blind: 2000, big_blind: 4000, duration: 20 },
-      { level: 13, small_blind: 3000, big_blind: 6000, duration: 20 },
-      { level: 14, small_blind: 4000, big_blind: 8000, duration: 20 },
-    ]
     levels: generateBlindLevels(20)
   },
   
   // Para stacks de 25,000 ou mais
   large: {
     name: 'Deep Stack (30 min)',
-    levels: [
-      { level: 1, small_blind: 100, big_blind: 100, duration: 30 },
-      { level: 2, small_blind: 100, big_blind: 200, duration: 30 },
-      { level: 3, small_blind: 100, big_blind: 300, duration: 30 },
-      { level: 4, small_blind: 200, big_blind: 400, duration: 30 },
-      { level: 5, small_blind: 300, big_blind: 600, duration: 30 },
-      { level: 6, small_blind: 400, big_blind: 800, duration: 30 },
-      { level: 7, small_blind: 500, big_blind: 1000, duration: 30 },
-      { level: 8, small_blind: 600, big_blind: 1200, duration: 30 },
-      { level: 9, small_blind: 800, big_blind: 1600, duration: 30 },
-      { level: 10, small_blind: 1000, big_blind: 2000, duration: 30 },
-      { level: 11, small_blind: 1500, big_blind: 3000, duration: 30 },
-      { level: 12, small_blind: 2000, big_blind: 4000, duration: 30 },
-      { level: 13, small_blind: 3000, big_blind: 6000, duration: 30 },
-      { level: 14, small_blind: 4000, big_blind: 8000, duration: 30 },
-      { level: 15, small_blind: 5000, big_blind: 10000, duration: 30 },
-      { level: 16, small_blind: 6000, big_blind: 12000, duration: 30 },
-    ]
     levels: generateBlindLevels(30)
   }
 };


### PR DESCRIPTION
## Summary
- show new TournamentDetails page in router
- fix blind structure utility syntax so tests run

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68405032f0208324afb1cf8010efff4c