### PR TITLE
Enable tournament registration with existing users

### DIFF
--- a/backend/src/controllers/userController.js
+++ b/backend/src/controllers/userController.js
@@ -121,6 +121,22 @@ const userController = {
       res.status(500).json({ error: 'Internal server error' });
     }
   }
+  ,
+  async list(req, res) {
+    try {
+      const { data: users, error } = await req.db
+        .from('users')
+        .select('id, name, email, role')
+        .order('name', { ascending: true });
+
+      if (error) throw error;
+
+      res.json(users);
+    } catch (error) {
+      console.error('List users error:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  }
 };
 
 module.exports = userController; 

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -4,6 +4,7 @@ const dotenv = require('dotenv');
 const database = require('./middleware/database');
 const authRoutes = require('./routes/auth');
 const tournamentRoutes = require('./routes/tournaments');
+const userRoutes = require('./routes/users');
 
 dotenv.config();
 
@@ -24,6 +25,7 @@ app.use(database);
 // Routes
 app.use('/api/auth', authRoutes);
 app.use('/api/tournaments', tournamentRoutes);
+app.use('/api/users', userRoutes);
 
 // Basic health check endpoint
 app.get('/health', (req, res) => {

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const userController = require('../controllers/userController');
+const { auth, checkRole } = require('../middleware/auth');
+
+router.get('/', auth, checkRole(['admin', 'staff']), userController.list);
+
+module.exports = router;

--- a/frontend/src/services/userService.js
+++ b/frontend/src/services/userService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
+const API_URL = '/api';
 
 const userService = {
   registerManual: async (userData) => {


### PR DESCRIPTION
## Summary
- add `GET /api/users` route and controller logic
- expose user routes from backend app
- allow PlayerManagement to fetch users and register an existing user
- adjust user service base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68408da89e4c8324919a419a0ec39fac