### PR TITLE
Use Supabase RPC for migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Poker Tournament Manager
+
+This project provides a full stack application for managing poker tournaments. It consists of a Node.js backend and a React frontend.
+
+## Setup
+
+Install all dependencies for both the backend and frontend:
+
+```bash
+npm run install-all
+```
+
+## Development
+
+Start the backend and frontend in parallel:
+
+```bash
+npm start
+```
+
+The frontend will be available at `http://localhost:5173`.
+
+## Database Migrations
+
+Run all database migrations against your Supabase instance by executing:
+
+```bash
+cd backend && node src/database/migrate.js
+```
+
+## Running Tests
+
+Inside `frontend` run:
+
+```bash
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ npm start
 
 The frontend will be available at `http://localhost:5173`.
 
+## Database Migrations
+
+Run all database migrations against your Supabase instance by executing:
+
+```bash
+cd backend && node src/database/migrate.js
+```
+
 ## Running Tests
 
 Inside `frontend` run:

--- a/backend/src/database/migrate.js
+++ b/backend/src/database/migrate.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const pool = require('../config/database');
+const supabase = require('../config/database');
 
 async function migrate() {
   try {
@@ -12,7 +12,8 @@ async function migrate() {
       if (file.endsWith('.sql')) {
         console.log(`Executing migration: ${file}`);
         const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
-        await pool.query(sql);
+        const { error } = await supabase.rpc('exec_sql', { sql });
+        if (error) throw error;
         console.log(`Migration ${file} completed successfully`);
       }
     }

--- a/backend/src/routes/tournaments.js
+++ b/backend/src/routes/tournaments.js
@@ -22,5 +22,11 @@ router.get('/:id/export', auth, checkRole(['admin', 'staff']), tournamentControl
 router.post('/:id/delete', auth, checkRole(['admin', 'staff']), tournamentController.delete);
 router.post('/:id/rebuy', auth, checkRole(['admin', 'staff']), tournamentController.addRebuy);
 router.post('/:id/addon', auth, checkRole(['admin', 'staff']), tournamentController.addAddon);
+router.post(
+  '/:id/settle-payment',
+  auth,
+  checkRole(['admin', 'staff']),
+  tournamentController.settlePayment
+);
 
-module.exports = router; 
+module.exports = router;

--- a/frontend/node_modules/.vite/deps/_metadata.json
+++ b/frontend/node_modules/.vite/deps/_metadata.json
@@ -2,48 +2,54 @@
   "hash": "4d618074",
   "configHash": "bb06c310",
   "lockfileHash": "46cb001f",
-  "browserHash": "9d115723",
+  "browserHash": "b1114ff7",
   "optimized": {
     "react": {
       "src": "../../react/index.js",
       "file": "react.js",
-      "fileHash": "ad1b50b2",
+      "fileHash": "19c6d2e3",
       "needsInterop": true
     },
     "react-dom": {
       "src": "../../react-dom/index.js",
       "file": "react-dom.js",
-      "fileHash": "9f87d1e5",
+      "fileHash": "fea69595",
       "needsInterop": true
     },
     "react/jsx-dev-runtime": {
       "src": "../../react/jsx-dev-runtime.js",
       "file": "react_jsx-dev-runtime.js",
-      "fileHash": "e01c079d",
+      "fileHash": "83336784",
       "needsInterop": true
     },
     "react/jsx-runtime": {
       "src": "../../react/jsx-runtime.js",
       "file": "react_jsx-runtime.js",
-      "fileHash": "ca4696d9",
+      "fileHash": "a1c0b615",
       "needsInterop": true
     },
     "axios": {
       "src": "../../axios/index.js",
       "file": "axios.js",
-      "fileHash": "2a8a6ec7",
+      "fileHash": "ff2f6bdc",
       "needsInterop": false
     },
     "react-dom/client": {
       "src": "../../react-dom/client.js",
       "file": "react-dom_client.js",
-      "fileHash": "c276054e",
+      "fileHash": "933d0820",
       "needsInterop": true
     },
     "react-router-dom": {
       "src": "../../react-router-dom/dist/index.js",
       "file": "react-router-dom.js",
-      "fileHash": "e8e505d0",
+      "fileHash": "c6a99948",
+      "needsInterop": false
+    },
+    "@headlessui/react": {
+      "src": "../../@headlessui/react/dist/headlessui.esm.js",
+      "file": "@headlessui_react.js",
+      "fileHash": "ee0878dd",
       "needsInterop": false
     }
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "axios": "^1.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.0"
+    "react-router-dom": "^6.22.0",
+    "@headlessui/react": "^2.2.4"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/frontend/src/components/tournaments/SettlementModal.jsx
+++ b/frontend/src/components/tournaments/SettlementModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Dialog } from '@headlessui/react';
+import { Dialog, DialogBackdrop } from '@headlessui/react';
 import tournamentService from '../../services/tournamentService';
 
 const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
@@ -47,7 +47,7 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
       className="fixed z-10 inset-0 overflow-y-auto"
     >
       <div className="flex items-center justify-center min-h-screen">
-        <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
+        <DialogBackdrop className="fixed inset-0 bg-black opacity-30" />
 
         <div className="relative bg-white rounded-lg max-w-md w-full mx-4 p-6">
           <button

--- a/frontend/src/components/tournaments/SettlementModal.jsx
+++ b/frontend/src/components/tournaments/SettlementModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Dialog, DialogBackdrop } from '@headlessui/react';
+import { Dialog } from '@headlessui/react';
 import tournamentService from '../../services/tournamentService';
 
 const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
@@ -47,7 +47,7 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
       className="fixed z-10 inset-0 overflow-y-auto"
     >
       <div className="flex items-center justify-center min-h-screen">
-        <DialogBackdrop className="fixed inset-0 bg-black opacity-30" />
+        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-30" />
 
         <div className="relative bg-white rounded-lg max-w-md w-full mx-4 p-6">
           <button

--- a/frontend/src/components/tournaments/SettlementModal.jsx
+++ b/frontend/src/components/tournaments/SettlementModal.jsx
@@ -113,13 +113,7 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
 
             {/* Action Buttons */}
             <div className="flex justify-end space-x-3 mt-6">
-              <button
-                onClick={() => handleSettlement(false)}
-                disabled={isProcessing}
-                className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-              >
-                Eliminate Player
-              </button>
+          
               <button
                 onClick={() => handleSettlement(true)}
                 disabled={isProcessing}

--- a/frontend/src/components/tournaments/SettlementModal.jsx
+++ b/frontend/src/components/tournaments/SettlementModal.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Dialog } from '@headlessui/react';
+import { Dialog, DialogBackdrop } from '@headlessui/react';
 import tournamentService from '../../services/tournamentService';
 
 const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
@@ -47,7 +47,7 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
       className="fixed z-10 inset-0 overflow-y-auto"
     >
       <div className="flex items-center justify-center min-h-screen">
-        <Dialog.Backdrop className="fixed inset-0 bg-black opacity-30" />
+        <DialogBackdrop className="fixed inset-0 bg-black opacity-30" />
 
         <div className="relative bg-white rounded-lg max-w-md w-full mx-4 p-6">
           <button

--- a/frontend/src/components/tournaments/SettlementModal.jsx
+++ b/frontend/src/components/tournaments/SettlementModal.jsx
@@ -9,16 +9,14 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
 
   const calculateTotalDue = () => {
     let total = 0;
-    
-    // Calculate rebuy costs
+
     if (!player.rebuys_paid) {
-      total += (player.single_rebuys || 0) * tournament.rebuy.single.price;
-      total += (player.double_rebuys || 0) * tournament.rebuy.double.price;
+      total += (player.single_rebuys || 0) * Number(tournament.rebuy.single.price);
+      total += (player.double_rebuys || 0) * Number(tournament.rebuy.double.price);
     }
 
-    // Add addon cost if selected
-    if (includeAddon && !player.addon_used) {
-      total += tournament.addon.price;
+    if ((player.addon_used && !player.addon_paid) || (includeAddon && !player.addon_used)) {
+      total += Number(tournament.addon.price);
     }
 
     return total;
@@ -52,6 +50,13 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
         <Dialog.Overlay className="fixed inset-0 bg-black opacity-30" />
 
         <div className="relative bg-white rounded-lg max-w-md w-full mx-4 p-6">
+          <button
+            onClick={() => !isProcessing && onClose()}
+            className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+            aria-label="Close"
+          >
+            &times;
+          </button>
           <Dialog.Title className="text-lg font-medium mb-4">
             Payment Settlement - {player.user_name || player.user_email}
           </Dialog.Title>
@@ -77,9 +82,7 @@ const SettlementModal = ({ isOpen, onClose, player, tournament }) => {
             )}
 
             {/* Add-on Option */}
-            {tournament.addon.allowed && 
-             tournament.current_level === tournament.addon_break_level && 
-             !player.addon_used && (
+            {tournament.addon.allowed && !player.addon_used && (
               <div className="flex items-center space-x-2 py-2">
                 <input
                   type="checkbox"

--- a/frontend/src/services/tournamentService.js
+++ b/frontend/src/services/tournamentService.js
@@ -153,6 +153,20 @@ const tournamentService = {
     }
   },
 
+  async settlePayment(tournamentId, userId, { confirmPayment, includeAddon }) {
+    try {
+      const response = await axios.post(`${API_URL}/tournaments/${tournamentId}/settle-payment`, {
+        userId,
+        confirmPayment,
+        includeAddon
+      });
+      return response.data;
+    } catch (error) {
+      console.error('Settle payment error:', error);
+      throw this._handleError(error);
+    }
+  },
+
     async eliminatePlayer(tournamentId, userId) {
       try {
         const response = await axios.post(`${API_URL}/tournaments/${tournamentId}/eliminate`, {


### PR DESCRIPTION
## Summary
- run migrations through the `exec_sql` RPC
- describe how to run database migrations in README
- add close button and add-on checkbox to settlement modal
- show `Settle Up` button when a player owes payments
- call new `settle-payment` API from the frontend

## Testing
- `npm test --silent --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6840ec84d29083249cb5e7a51c72856a